### PR TITLE
Avoid repeating work in ranged substring operations

### DIFF
--- a/Sources/Stryng.swift
+++ b/Sources/Stryng.swift
@@ -18,15 +18,15 @@ public extension String {
 
     // String[0..<1]
     public subscript(range: Range<Int>) -> Substring? {
-        guard let left = index(startIndex, offsetBy: range.lowerBound, limitedBy: endIndex) else { return nil }
-        guard let right = index(startIndex, offsetBy: range.upperBound, limitedBy: endIndex) else { return nil }
+        guard let left = indexOffset(by: range.lowerBound) else { return nil }
+        guard let right = index(left, offsetBy: range.upperBound - range.lowerBound, limitedBy: endIndex) else { return nil }
         return self[left..<right]
     }
 
     // String[0...1]
     public subscript(range: ClosedRange<Int>) -> Substring? {
-        guard let left = index(startIndex, offsetBy: range.lowerBound, limitedBy: endIndex) else { return nil }
-        guard let right = index(startIndex, offsetBy: range.upperBound, limitedBy: endIndex) else { return nil }
+        guard let left = indexOffset(by: range.lowerBound) else { return nil }
+        guard let right = index(left, offsetBy: range.upperBound - range.lowerBound, limitedBy: endIndex) else { return nil }
         return self[left...right]
     }
 


### PR DESCRIPTION
Instead of computing from the start index to the end index for both the left and right sides of a ranged subscript, compute the index from the left-hand side.

This will remove a lot of work, especially if the indices are far into the string. For example:

```swift
let str = aTaleOfTwoCities[1000..<1005]
```

Previously this would walk 0 to 1000, then 0 to 1005. Now this will walk 0 to 1000, then 1000 to 1005.