### PR TITLE
Add Swift Package Manager installation instructions to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,14 +110,27 @@ public subscript(range: PartialRangeFrom<String>) -> PartialRangeFrom<String.Ind
 public subscript(range: PartialRangeThrough<String>) -> PartialRangeThrough<String.Index>?
 ```
 
-## Installation (Swift Package Manager)
-In your `Package.swift` file, add the following line to your `dependencies` array:
+## Installation
+
+### Cocoapods
+
+To install via [Cocoapods](http://cocoapods.org/), add the following line to your Podfile:
+
+```
+pod Stryng
+```
+
+### Swift Package Manager
+
+To install via the [Swift Package Manager](https://swift.org/package-manager/), add the following line to the `dependencies` array in your `Package.swift` file:
 
 ```
 .package(url: "https://github.com/BalestraPatrick/Stryng.git", from: "0.4.1")
 ```
 
-Then, in your terminal, run the following command to update your dependencies:
+Then, still in your `Package.swift`, add `"Stryng"` to your *target's* `dependencies` array.
+
+Finally, in your terminal, run the following command to update your dependencies:
 
 ```
 $ swift package update

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ public subscript(range: PartialRangeThrough<String>) -> PartialRangeThrough<Stri
 
 To install via [Cocoapods](http://cocoapods.org/), add the following line to your Podfile:
 
-```
+```ruby
 pod Stryng
 ```
 
@@ -124,7 +124,7 @@ pod Stryng
 
 To install via the [Swift Package Manager](https://swift.org/package-manager/), add the following line to the `dependencies` array in your `Package.swift` file:
 
-```
+```swift
 .package(url: "https://github.com/BalestraPatrick/Stryng.git", from: "0.4.1")
 ```
 
@@ -132,7 +132,7 @@ Then, still in your `Package.swift`, add `"Stryng"` to your *target's* `dependen
 
 Finally, in your terminal, run the following command to update your dependencies:
 
-```
+```bash
 $ swift package update
 ```
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,19 @@ public subscript(range: PartialRangeFrom<String>) -> PartialRangeFrom<String.Ind
 public subscript(range: PartialRangeThrough<String>) -> PartialRangeThrough<String.Index>?
 ```
 
+## Installation (Swift Package Manager)
+In your `Package.swift` file, add the following line to your `dependencies` array:
+
+```
+.package(url: "https://github.com/BalestraPatrick/Stryng.git", from: "0.4.1")
+```
+
+Then, in your terminal, run the following command to update your dependencies:
+
+```
+$ swift package update
+```
+
 ## Disclosure
 Yes, string traversal in Swift can be slow. The reason why these subscripts don't exist in the standard library is that some people think that it hides the performance implications of traversing a string. Traversing a string from the `startIndex` until the `endIndex` has complexity O(n). 
 If you need to get a character at a specific index, in one way or another you will have to traverse the string, but why would you need 3 lines of code instead of 1 to do that if you know what you're doing?


### PR DESCRIPTION
Lots of packages in other communities have installation instructions (even if it's just a Terminal one-liner) in the Readme to help people who might not have much familiarity with the ecosystem. When I was installing this package, I realized I wanted similar instructions in *this* package's Readme, so this PR adds them.

Feel free to edit or reject, I'm not all that experienced with open source contributing